### PR TITLE
DP-12531 migrate users of cc-mk-include self updating to use service-bot updating

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -7,3 +7,7 @@ github:
   enable: true
 semaphore:
   enable: true
+make:
+  enable: true
+  update_makefile: false
+  enable_updates: true


### PR DESCRIPTION
In preparation for using service-bot to roll out the next revision of separated
build-time mk-include fetch and unpack, all mk-include client repos need to be
opted in to using service-bot for mk-include content management and updates.

See https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3046114540/Refactor+cc-mk-include+deployment+with+build+reproducibility
