### PR TITLE
DP-12820 followup - remove unused connect access and secret keys

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -35,7 +35,6 @@ blocks:
           - checkout
           - make show-args
           - . vault-setup
-          - . vault-sem-get-secret aws_credentials
           - . vault-sem-get-secret semaphore-secrets-global
           - . vault-sem-get-secret cpd_gcloud
           - . vault-sem-get-secret ci-reporting


### PR DESCRIPTION
## Background
This is a followup to DP-12820 to remove the connect_aws_credentials pending eventual deactivation as the secret is used in connect system tests
and contains a script to authenticate with the caas-dev 037803949979:semaphoreci user. This will be replaced with dynamic iam role based access.

## Changes
This PR removes the `connect_aws_credentials` which is likely not needed in your pipeline.

## Actions
If the PR build succeeds, and the secret is only used in the semaphore.yml file, please merge this change.

For questions, please reach out to #devprod-oncall, and for more details, please see: https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3033867557/CI+System+Migration+Jenkins-+Semaphore#Secrets
