### PR TITLE
DP-12531 ensure service-bot git.enable and make.enable_updates are true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 GOARCH = amd64
 MASTER_BRANCH ?= main
 
-UPDATE_MK_INCLUDE := true
-UPDATE_MK_INCLUDE_AUTO_MERGE := true
+UPDATE_MK_INCLUDE := false
+UPDATE_MK_INCLUDE_AUTO_MERGE := false
 SERVICE_NAME := pie-cc-hashicorp-vault-plugin
 IMAGE_NAME := $(SERVICE_NAME)
 BASE_IMAGE := golang


### PR DESCRIPTION
mk-include `make update-mk-include` support has been disabled for a few
months.

Without git.enable, service-bot will not push changes to the mk-include
tree with nightly PRs; and without make.enable_updates set to true, any
checked in out-of-date mk-include subtree will not be removed.  Both of
these things are prerequisites for separated cc-mk-include migration to
be considered complete.

See https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3046114540/Refactor+cc-mk-include+deployment+with+build+reproducibility
