### PR TITLE
[DP-13434] cleanup pipeline by removing unnecessary secrets and commands

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -32,8 +32,6 @@ blocks:
           - checkout
           - make show-args
           - . vault-setup
-          - . vault-sem-get-secret aws_credentials
-          - . vault-sem-get-secret cpd_gcloud
           - . vault-sem-get-secret ci-reporting
           - . vault-sem-get-secret v1/ci/kv/service-foundations/cc-mk-include
           - make init-ci
@@ -50,7 +48,6 @@ blocks:
       prologue:
         commands:
           - checkout
-          - . vault-sem-get-secret gradle_properties
           - make docker-login-ci
           - sem-version java 8
       jobs:


### PR DESCRIPTION
## Background
This PR is a followup to DP-12820 to clean up Semaphore pipelines. It brings the pipeline up to the latest standards by:
* removing unnecessary commands and secrets
* replacing deprecated commands and secrets with active ones

The vast majority of these secrets and commands are now set automatically on the Semaphore agents, so there is no need to set them specifically in the pipeline. The ones that remain are the ones that are not used globally and are specific to the pipeline's use case.

## Actions
Please approve and merge this change. If status checks are failing, please debug as necessary.
