### PR TITLE
[DP-15772] cleanup Semaphore pipeline

### DIFF
--- a/.semaphore/goreleaser.yaml
+++ b/.semaphore/goreleaser.yaml
@@ -13,7 +13,6 @@ global_job_config:
       - export "TMPDIR=$(mktemp -d)"
       - export "PATH=${TMPDIR}:${GOPATH}/bin:${PATH}"
       - mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"
-      - git config --global url."git@github.com:".insteadOf "https://github.com/"
       - checkout
       - . vault-setup
       - . vault-sem-get-secret ci-reporting


### PR DESCRIPTION
## Background
This PR brings the pipeline up to the latest standards by:
* removing unnecessary commands and secrets - They are set automatically on the Semaphore agents.
* replacing deprecated commands and secrets with active ones - The deprecated secrets will be deleted.
* updating the Python version to 3.11 (if necessary) - The previous version is EOL and no longer installed on Semaphore agents. This will speed up the pipeline.

If this PR is not merged, the pipeline may begin to fail due to the removal of deprecated commands and secrets or incompatibility.

## Actions
Please approve and merge this change. If status checks are failing, please debug as necessary.
